### PR TITLE
Traceback

### DIFF
--- a/lib/soap/mapping/mapping.rb
+++ b/lib/soap/mapping/mapping.rb
@@ -541,8 +541,8 @@ module Mapping
   private
 
     def class_schema_variable(sym, klass)
-      var = "@@#{sym}".to_sym
-      klass.class_variables.include?(var) ? klass.class_eval(var) : nil
+      var = "@@#{sym}"
+      klass.class_variables.include?(var.to_sym) ? klass.class_eval(var) : nil
     end
 
     def protect_mapping(opt)


### PR DESCRIPTION
When I upgraded from ruby 1.8 and ruby 1.9 I used your soap4r replacement (mainly because it has the gem stuff).

I got the following traceback when trying to use a driver that I'd generated under soap4r under ruby 1.85

/home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:545:in `class_eval': can't convert Symbol into String (TypeError)
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:545:in`class_schema_variable'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:394:in `schema_ns_definition'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:421:in`schema_definition_classdef'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/registry.rb:199:in `schema_definition_from_class'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/encodedregistry.rb:341:in`_obj2soap'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/encodedregistry.rb:301:in `obj2soap'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:135:in`_obj2soap'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:54:in `block (2 levels) in objs2soap'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:52:in`upto'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:52:in `block in objs2soap'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:560:in`block in protect_mapping'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:533:in `protect_threadvars'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:549:in`protect_mapping'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/mapping/mapping.rb:51:in `objs2soap'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/rpc/proxy.rb:475:in`request_rpc_enc'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/rpc/proxy.rb:457:in `request_rpc'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/rpc/proxy.rb:412:in`request_body'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/rpc/proxy.rb:127:in `call'
    from /home/mattrose/.gem/ruby/1.9.1/gems/soap4r-ruby1.9-2.0.5/lib/soap/rpc/driver.rb:151:in`call'
    from (eval):6:in `server_List'
    from /home/mattrose/bin/admin:130:in`<main>'
