### PR TITLE
No String.each in Ruby 1.9

### DIFF
--- a/lib/soap/mimemessage.rb
+++ b/lib/soap/mimemessage.rb
@@ -49,7 +49,7 @@ class MIMEMessage
 
     def parse(str)
       header_cache = nil
-      str.each do |line|
+      str.each_line do |line|
 	case line
 	when /^\A[^\: \t]+:\s*.+$/
 	  parse_line(header_cache) if header_cache


### PR DESCRIPTION
See:
https://github.com/noeticpenguin/soap4r-noeticpenguin/issues/9
