### PR TITLE
remove deprecated ::Data constant

### DIFF
--- a/lib/soap/mapping/rubytypeFactory.rb
+++ b/lib/soap/mapping/rubytypeFactory.rb
@@ -193,7 +193,7 @@ class RubytypeFactory < Factory
         param.add('member', ele_member)
         addiv2soapattr(param, obj, map)
       end
-    when ::IO, ::Binding, ::Data, ::Dir, ::File::Stat,
+    when ::IO, ::Binding, ::Dir, ::File::Stat,
         ::MatchData, Method, ::Proc, ::Process::Status, ::Thread,
         ::ThreadGroup, ::UnboundMethod
       return nil


### PR DESCRIPTION
::Data is a deprecated constant and a warning is emitted in ruby2.7.
See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=954775